### PR TITLE
Fix ocp_tessellate install command package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -471,7 +471,7 @@
                         },
                         "ocp_tessellate": {
                             "pip": [
-                                "{python} -m pip install --upgrade 'ocp_tessellate>=1.1.0,<1.2.0'"
+                                "{python} -m pip install --upgrade \"ocp_tessellate>=1.1.0,<1.2.0\""
                             ],
                             "poetry": [
                                 "poetry add ocp_tessellate@~1.1.0"


### PR DESCRIPTION
used escape double quotes for the pip install "string"