### PR TITLE
Work in progress: passing viewer port to python via command substitution in launch.json

### DIFF
--- a/ocp_vscode/comms.py
+++ b/ocp_vscode/comms.py
@@ -2,9 +2,16 @@ import enum
 from websockets.sync.client import connect
 import orjson as json
 from ocp_tessellate.utils import Timer
+import os
 
 CMD_URL = "ws://127.0.0.1"
 CMD_PORT = 3939
+
+if "ocp_port" in os.environ:
+    try:
+        CMD_PORT = int(os.environ["ocp_port"])
+    except ValueError:
+        pass
 
 #
 # Send data to the viewer

--- a/ocp_vscode/comms.py
+++ b/ocp_vscode/comms.py
@@ -7,11 +7,10 @@ import os
 CMD_URL = "ws://127.0.0.1"
 CMD_PORT = 3939
 
-if "ocp_port" in os.environ:
-    try:
-        CMD_PORT = int(os.environ["ocp_port"])
-    except ValueError:
-        pass
+try:
+    CMD_PORT = int(os.environ["ocp_port"])
+except (ValueError, KeyError):
+    pass
 
 #
 # Send data to the viewer

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:ocpCadViewer.ocpCadViewer"
+        "onCommand:ocpCadViewer.ocpCadViewer",
+        "onCommand:ocpCadViewer.port"
     ],
     "main": "./out/extension.js",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,6 +105,9 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             "ocpCadViewer.port",
             async () => {
+                if(!controller){
+                    vscode.commands.executeCommand("ocpCadViewer.ocpCadViewer");
+                }
                 return controller?controller.port.toString() : "3939";
             }
         )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,6 +103,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand(
+            "ocpCadViewer.port",
+            async () => {
+                return controller.port;
+            }
+        )
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
             "ocpCadViewer.ocpCadViewer",
             async () => {
                 output.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             "ocpCadViewer.port",
             async () => {
-                return controller.port.toString();
+                return controller?controller.port.toString() : "3939";
             }
         )
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             "ocpCadViewer.port",
             async () => {
-                return controller.port;
+                return controller.port.toString();
             }
         )
     );


### PR DESCRIPTION
Launch.json used:

```json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Python: Current File",
            "type": "python",
            "request": "launch",
            "program": "${file}",
            "args": ["--port", "${command:ocpCadViewer.port}"],
            "env": {"ocp_port": "${command:ocpCadViewer.port}"},
            "console": "integratedTerminal",
            "justMyCode": false
        }
    ]
}
```

Seems to work, the command is launched with --port 3939 as expected. May need some checks in case the viewer isn't running yet, and maybe even auto-starting the viewer when ocpCadViewer.port command is called.