### PR TITLE
Replace build123d.downcast with locally defined downcast

### DIFF
--- a/ocp_vscode/backend.py
+++ b/ocp_vscode/backend.py
@@ -19,7 +19,7 @@ from build123d import (
     Compound,
     Location,
 )
-from build123d.topology import downcast
+from ocp_vscode.persistence import downcast
 from ocp_tessellate.tessellator import (
     face_mapper,
     edge_mapper,

--- a/ocp_vscode/persistence.py
+++ b/ocp_vscode/persistence.py
@@ -1,5 +1,6 @@
 from OCP.BinTools import BinTools
 from OCP.TopoDS import (
+    TopoDS,
     TopoDS_Shape,
     TopoDS_Compound,
     TopoDS_CompSolid,
@@ -11,11 +12,23 @@ from OCP.TopoDS import (
     TopoDS_Vertex,
 )
 from OCP.TopAbs import TopAbs_ShapeEnum
+import OCP.TopAbs as ta
 from OCP.TopLoc import TopLoc_Location
 from OCP.gp import gp_Trsf, gp_Quaternion, gp_Vec
 import io
 import copyreg
 import struct
+
+downcast_LUT = {
+    ta.TopAbs_VERTEX: TopoDS.Vertex_s,
+    ta.TopAbs_EDGE: TopoDS.Edge_s,
+    ta.TopAbs_WIRE: TopoDS.Wire_s,
+    ta.TopAbs_FACE: TopoDS.Face_s,
+    ta.TopAbs_SHELL: TopoDS.Shell_s,
+    ta.TopAbs_SOLID: TopoDS.Solid_s,
+    ta.TopAbs_COMPOUND: TopoDS.Compound_s,
+    ta.TopAbs_COMPSOLID: TopoDS.CompSolid_s,
+}
 
 def shapetype(obj: TopoDS_Shape) -> TopAbs_ShapeEnum:
     """Return TopoDS_Shape's TopAbs_ShapeEnum"""


### PR DESCRIPTION
This is a partial solution to `ocp_vscode` depending on `build123d`, but there are still further areas that would need to be decoupled.