### PR TITLE
comms.py -> fix conflicting double quote with single quote in f-string

### DIFF
--- a/ocp_vscode/comms.py
+++ b/ocp_vscode/comms.py
@@ -319,7 +319,7 @@ def find_and_set_port():
         port = int(os.environ.get("OCP_PORT", "0"))
     except ValueError as ex:
         print(
-            f"Port {os.environ.get("OCP_PORT")} taken from environment variable OCP_PORT is invalid"
+            f"Port {os.environ.get('OCP_PORT')} taken from environment variable OCP_PORT is invalid"
         )
         port = 0
 


### PR DESCRIPTION
Observed an error due to this on glob import of ocp_vscode