### PR TITLE
Add missing default param for tree_width

### DIFF
--- a/ocp_vscode/__main__.py
+++ b/ocp_vscode/__main__.py
@@ -105,6 +105,7 @@ def track_param(ctx, param, value):
 )
 @click.option(
     "--tree_width",
+    default=240,
     help="OCP CAD Viewer navigation tree width (default: 240)",
     callback=track_param,
 )


### PR DESCRIPTION
As per https://github.com/bernhard-42/vscode-ocp-cad-viewer/issues/200