### PR TITLE
fix(show): prefer pymat.Material.pbr_source over lossy field-copy

### DIFF
--- a/ocp_vscode/show.py
+++ b/ocp_vscode/show.py
@@ -171,21 +171,37 @@ def _extract_materials_from_node(node, extracted, id_to_key, name_counts):
 
         # pymat.Material
         elif is_pymat(node.material):
-            pbr = node.material.properties.pbr
-            mat = PbrProperties.create(
-                node.material.name,
-                color=pbr.base_color,
-                metalness=pbr.metallic,
-                roughness=pbr.roughness,
-                emissive=pbr.emissive,
-                ior=pbr.ior,
-                transmission=pbr.transmission,
-                clearcoat=pbr.clearcoat,
-                normal_map=pbr.normal_map,
-                roughness_map=pbr.roughness_map,
-                metalness_map=pbr.metallic_map,
-                ao_map=pbr.ambient_occlusion_map,
-            )
+            # Prefer the rich `pbr_source` when the caller assigned
+            # one — it's already a `PbrProperties` with the full set
+            # of texture maps (color/albedo, normal, roughness,
+            # metalness, ao, etc.) plus every Three.js
+            # MeshPhysicalMaterial scalar that py-materials' lite
+            # dataclass doesn't model (sheen, anisotropy, iridescence,
+            # dispersion, clearcoat maps, specular, thickness, etc.).
+            # Bypassing the field-by-field copy below avoids lossy
+            # projection through py-materials' lite PBRProperties
+            # dataclass, which has no `base_color_map` field and
+            # therefore silently drops the color/albedo texture —
+            # rendering e.g. gpuopen's "Ivory Walnut Solid Wood" as
+            # a flat white mesh. See MorePET/mat#3 and ADR-0002.
+            if getattr(node.material, "pbr_source", None) is not None:
+                mat = node.material.pbr_source
+            else:
+                pbr = node.material.properties.pbr
+                mat = PbrProperties.create(
+                    node.material.name,
+                    color=pbr.base_color,
+                    metalness=pbr.metallic,
+                    roughness=pbr.roughness,
+                    emissive=pbr.emissive,
+                    ior=pbr.ior,
+                    transmission=pbr.transmission,
+                    clearcoat=pbr.clearcoat,
+                    normal_map=pbr.normal_map,
+                    roughness_map=pbr.roughness_map,
+                    metalness_map=pbr.metallic_map,
+                    ao_map=pbr.ambient_occlusion_map,
+                )
 
         # build123d.Material
         elif (


### PR DESCRIPTION
## Draft — pending confirmation from @bernhard-42 + @gumyr

Opened as a **draft** because this is part of the wider collaboration thread in [MorePET/mat#3](https://github.com/MorePET/mat/issues/3) — happy to rework, rename, or split as needed. The fix itself is small and surgical, but the direction is worth confirming before merging.

## Bug

When a \`pymat.Material\` carries a rich \`pbr_source\` (a \`threejs_materials.PbrProperties\` instance), \`_extract_materials_from_node\` in \`ocp_vscode/show.py\` takes the \`is_pymat(node.material)\` branch and calls \`PbrProperties.create(...)\` by hand-copying fields from the lite \`pymat.properties.pbr\` dataclass. That dataclass **has no \`base_color_map\` / albedo field**, so the color texture is silently dropped.

For materials whose visual identity lives in the color map — wood, bricks, tiles, stone, most non-metal MaterialX libraries — this renders them as flat white meshes even when a valid \`pbr_source\` is assigned. Metal materials accidentally survived because their visual character comes from scalar \`metalness=1\` + \`roughness\` + env reflections, not a color map.

## Repro

\`\`\`python
from build123d import Box
from pymat import Material
from pymat.pbr import PbrProperties  # = threejs_materials.PbrProperties via pymat's [pbr] extra
from ocp_vscode import show, StudioEnvironment, StudioTextureMapping

part = Box(200, 200, 20)

# Direct PbrProperties → renders with wood grain (fast path via
# \`isinstance(node.material, PbrProperties)\`)
part.material = PbrProperties.from_gpuopen("Ivory Walnut Solid Wood")
show(part, studio_environment=StudioEnvironment.PROCEDURAL_STUDIO,
      studio_texture_mapping=StudioTextureMapping.PARAMETRIC)

# pymat wrapper → renders as FLAT WHITE (is_pymat() branch drops color map)
steel = Material(name="Walnut", density=0.65,
                  pbr_source=PbrProperties.from_gpuopen("Ivory Walnut Solid Wood"))
part.material = steel
show(part, studio_environment=StudioEnvironment.PROCEDURAL_STUDIO,
      studio_texture_mapping=StudioTextureMapping.PARAMETRIC)
\`\`\`

## Fix

1 conditional + 2 lines: prefer \`pbr_source\` when set, fall back to the existing field-by-field copy when not.

\`\`\`python
elif is_pymat(node.material):
    if getattr(node.material, "pbr_source", None) is not None:
        mat = node.material.pbr_source
    else:
        pbr = node.material.properties.pbr
        mat = PbrProperties.create(...)  # existing path, unchanged
\`\`\`

Backward compatible: materials without a rich \`pbr_source\` (TOML-authored, lite-only) continue through the original code path unchanged. The rich source path additionally picks up every Three.js MeshPhysicalMaterial scalar that py-materials' lite dataclass doesn't model (sheen, anisotropy, iridescence, dispersion, clearcoat maps, specular, thickness, etc.) — these were previously unreachable through the pymat path.

## Verified locally

Installed the patched \`ocp_vscode\` in a build123d venv and confirmed both branches:

- \`part.material = PbrProperties.from_gpuopen("Ivory Walnut Solid Wood")\` → wood grain ✅ (unchanged, \`isinstance(node.material, PbrProperties)\` fast path)
- \`part.material = pymat.Material(..., pbr_source=<same>)\` → wood grain ✅ (new behavior — was flat white)

## Context

This is part of a three-repo collaboration following [MorePET/mat#3](https://github.com/MorePET/mat/issues/3), where @gumyr proposed py-materials become the canonical \`Shape.material\` type for build123d:

- **[MorePET/mat#30](https://github.com/MorePET/mat/pull/30)** — py-materials draft PR adding \`Material.pbr_source\` + the \`pbr\` optional extra + the \`PbrSource\` Protocol. ADR-0002 captures the design rationale.
- **[gumyr/build123d#1276](https://github.com/gumyr/build123d/pull/1276)** — build123d draft PR widening \`Compound.material\` / \`Solid.material\` from \`str\` to \`str | pymat.Material | None\`.
- **This PR** — the adapter fix that makes the pymat path actually render textures correctly.

cc @gumyr

🤖 Generated with [Claude Code](https://claude.com/claude-code)