### PR TITLE
updated comms.js to handle ports and schemas properly through an ssl …

### DIFF
--- a/ocp_vscode/static/js/comms.js
+++ b/ocp_vscode/static/js/comms.js
@@ -13,7 +13,15 @@ class Comms {
     }
 
     createWebsocket() {
-        this.socket = new WebSocket(`ws://${this.host}:${this.port}`);
+        const isSecure = window.location.protocol === "https:";
+        const scheme = isSecure ? "wss" : "ws";
+        const portStr = String(this.port ?? "");
+        const isDefaultPort =
+        (isSecure && (portStr === "443" || portStr === "")) ||
+        (!isSecure && (portStr === "80" || portStr === ""));
+        const hostPort = isDefaultPort ? this.host : `${this.host}:${this.port}`;
+
+        this.socket = new WebSocket(`${scheme}://${hostPort}`);
         this.ready = false;
         this.retry++;
 


### PR DESCRIPTION
…proxy addressing https://github.com/bernhard-42/vscode-ocp-cad-viewer/issues/230

note: make tests was failing for me, but the same failures showed in d0bc3ff as well